### PR TITLE
ci: adjust the GitHub CI pipeline to chmod before running any gradlew commands

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Get apk path
         id: debugApk
-        run: echo "apkfile=$(find src/app/build/outputs/apk/release/*.apk)" >> $GITHUB_OUTPUT
+        run: echo "apkfile=$(find src/app/build/outputs/apk/debug/*.apk)" >> $GITHUB_OUTPUT
       
       - name: Upload apk
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,12 +20,12 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
 
-      - name: Update Gradle Wrapper to 8.10.2
-        run: ./gradlew wrapper --gradle-version 8.10.2
-        working-directory: src
-
       - name: Make gradlew executable
         run: chmod +x ./gradlew
+        working-directory: src
+
+      - name: Update Gradle Wrapper to 8.10.2
+        run: ./gradlew wrapper --gradle-version 8.10.2
         working-directory: src
 
       - name: Build Debug apk

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,11 +32,11 @@ jobs:
         java-version: 17
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3
-    - name: Update Gradle Wrapper to 8.10.2
-      run: ./gradlew wrapper --gradle-version 8.10.2
-      working-directory: src
     - name: Make gradlew executable
       run: chmod +x ./gradlew
+      working-directory: src
+    - name: Update Gradle Wrapper to 8.10.2
+      run: ./gradlew wrapper --gradle-version 8.10.2
       working-directory: src
     - name: Build Debug apk
       run: ./gradlew assembleDebug --stacktrace --no-daemon

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,10 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
 
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: src
+
       - name: Update Gradle Wrapper to 8.10.2
         run: ./gradlew wrapper --gradle-version 8.10.2
         working-directory: src
@@ -28,10 +32,6 @@ jobs:
             ENCODED_STRING: ${{ secrets.KEYSTORE }}
         run: echo $ENCODED_STRING | base64 -di > key.jks
         
-      - name: Make gradlew executable
-        run: chmod +x ./gradlew
-        working-directory: src
-
       - name: Build Release apk
         env:
           RELEASE_KEYSTORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vincentscode/Dino-Stickerpack/pull/27?shareId=34c159bf-ed47-4d4b-8be1-07f9de91a703).